### PR TITLE
Replace upickle with borer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,17 @@
 // heavily inspired by https://github.com/sjrd/scalajs-sbt-vite-laminar-chartjs-example/blob/laminar-scalablytyped-end-state/build.sbt
 
-scalaVersion := "3.2.2"
+scalaVersion := "3.3.0-RC5"
 scalacOptions ++= Seq("-encoding", "utf-8", "-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
   "org.scala-js"                  %%% "scalajs-dom"                 % "2.4.0",
   "org.scala-js"                  %%% "scala-js-macrotask-executor" % "1.1.1",
-  "com.softwaremill.sttp.client3" %%% "core"                        % "3.8.13",
+  "com.softwaremill.sttp.client3" %%% "core"                        % "3.8.15",
   "com.raquo"                     %%% "laminar"                     % "15.0.1",
   "com.raquo"                     %%% "waypoint"                    % "6.0.0",
   "io.github.cquiroz"             %%% "scala-java-time"             % "2.5.0",
-  "com.lihaoyi"                   %%% "upickle"                     % "3.0.0",
+  "io.bullet"                     %%% "borer-core"                  % "1.10.2",
+  "io.bullet"                     %%% "borer-derivation"            % "1.10.2",
   "com.lihaoyi"                   %%% "utest"                       % "0.8.1" % "test"
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"                % "sbt-scalajs"   % "1.13.0")
+addSbtPlugin("org.scala-js"                % "sbt-scalajs"   % "1.13.1")
 addSbtPlugin("org.scalablytyped.converter" % "sbt-converter" % "1.0.0-beta40")
 addSbtPlugin("org.scalameta"               % "sbt-scalafmt"  % "2.4.6")
 addSbtPlugin("de.heikoseeberger"           % "sbt-header"    % "5.9.0")


### PR DESCRIPTION
upickle started to throw this compilation error:

```
[error] -- [E172] Type Error: /Users/martynas/projects/rallyeye/src/main/scala/Router.scala:29:38 
[error]  29 |  implicit val rw: ReadWriter[Page] = macroRW
[error]     |                                      ^^^^^^^
[error]     |No given instance of type ReadersVersionSpecific_this.Reader[rallyeye.Router.IndexPage.type] was found.
[error]     |I found:
[error]     |
[error]     |    upickle.default.superTypeReader[rallyeye.Router.IndexPage.type, V](
[error]     |      rallyeye.Router.IndexPage.$asInstanceOf[
[error]     |        
[error]     |          scala.deriving.Mirror.Singleton{
[error]     |            type MirroredMonoType = rallyeye.Router.IndexPage.type;
[error]     |              type MirroredType = rallyeye.Router.IndexPage.type;
[error]     |              type MirroredLabel = ("IndexPage" : String)
[error]     |          }
[error]     |        
[error]     |      ],
[error]     |    rallyeye.Router.rw,
[error]     |      {
[error]     |        final class $anon() extends Object(), Serializable {
[error]     |          type MirroredMonoType² = rallyeye.Router.Page
[error]     |        }
[error]     |        (new $anon():Object & Serializable)
[error]     |      }.$asInstanceOf[
[error]     |        
[error]     |          scala.deriving.Mirror.Sum{
[error]     |            type MirroredMonoType³ = rallyeye.Router.Page;
[error]     |              type MirroredType = rallyeye.Router.Page;
[error]     |              type MirroredLabel = ("Page" : String);
[error]     |              type MirroredElemTypes = (rallyeye.Router.IndexPage.type,
[error]     |                rallyeye.Router.RallyPage);
[error]     |              type MirroredElemLabels = (("IndexPage" : String),
[error]     |                ("RallyPage" : String))
[error]     |          }
[error]     |        
[error]     |      ],
[error]     |    /* missing */summon[util.NotGiven[upickle.core.CurrentlyDeriving[V]]])
[error]     |
[error]     |But no implicit values were found that match type util.NotGiven[upickle.core.CurrentlyDeriving[V]]
[error]     |
[error]     |where:    MirroredMonoType  is a type in trait Singleton which is an alias of (Singleton.this : scala.deriving.Mirror.Singleton)
[error]     |          MirroredMonoType² is a type in an anonymous class in object Router which is an alias of rallyeye.Router.Page
[error]     |          MirroredMonoType³ is a type in trait Mirror with bounds 
[error]     |.
[error]     |
[error]     |The following import might make progress towards fixing the problem:
[error]     |
[error]     |  import upickle.default.ReadWriter.join
```

And there seems to be an issue with larger classes and Scala 3: https://github.com/com-lihaoyi/upickle/issues/386