### PR TITLE
Set results cache timeout to 5 minutes

### DIFF
--- a/modules/backend/src/main/scala/RallyEye.scala
+++ b/modules/backend/src/main/scala/RallyEye.scala
@@ -23,6 +23,7 @@ import cats.effect.IO
 import cats.effect.IOApp
 import cats.effect.LiftIO
 import com.comcast.ip4s._
+import io.chrisdavenport.mules.TimeSpec
 import io.chrisdavenport.mules.caffeine.CaffeineCache
 import io.chrisdavenport.mules.http4s.CacheItem
 import io.chrisdavenport.mules.http4s.CacheMiddleware
@@ -95,7 +96,8 @@ object Data extends IOApp.Simple:
     )).orNotFound
 
     for
-      caffeine <- CaffeineCache.build[IO, (Method, org.http4s.Uri), CacheItem](None, None, Some(100))
+      caffeine <- CaffeineCache
+        .build[IO, (Method, org.http4s.Uri), CacheItem](TimeSpec.fromDuration(5.minutes), None, Some(100))
       cache = CacheMiddleware.httpApp(caffeine, CacheType.Public)
       server <- EmberServerBuilder
         .default[IO]


### PR DESCRIPTION
This should make it easier to follow results realtime.