### PR TITLE
Use inner shadow

### DIFF
--- a/modules/frontend/src/main/scala/components/Header.scala
+++ b/modules/frontend/src/main/scala/components/Header.scala
@@ -47,7 +47,7 @@ case class Header(
 
   def render() =
     navTag(
-      cls := "bg-white border-gray-200 px-4 lg:px-6 py-2.5 shadow-lg",
+      cls := "bg-white border-gray-200 px-4 lg:px-6 py-2.5",
       div(
         cls := "flex flex-wrap justify-between items-center mx-auto max-w-screen-xl",
         a(

--- a/modules/frontend/src/main/scala/components/RallyResult.scala
+++ b/modules/frontend/src/main/scala/components/RallyResult.scala
@@ -48,7 +48,7 @@ case class RallyResult(
     div(
       display.flex,
       div(
-        cls := "p-4 text-xs",
+        cls := "p-4 text-xs shadow-inner",
         display.grid,
         gridTemplateColumns := "auto auto",
         div(


### PR DESCRIPTION
So it extends across the whole width of stage results.