### PR TITLE
Add database for result storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+rallyeye.db

--- a/build.sbt
+++ b/build.sbt
@@ -94,17 +94,32 @@ lazy val backend = project
       "com.softwaremill.sttp.tapir" %% "tapir-http4s-client" % "1.9.0",
       "org.http4s"                  %% "http4s-ember-server" % "0.23.23",
       "org.http4s"                  %% "http4s-ember-client" % "0.23.23",
-      "io.chrisdavenport"           %% "mules-http4s"        % "0.4.0",
-      "io.chrisdavenport"           %% "mules-caffeine"      % "0.7.0",
       "ch.qos.logback"               % "logback-classic"     % "1.4.11",
+      "com.github.geirolz"          %% "fly4s-core"          % "0.0.19",
+      "org.flywaydb"                 % "flyway-core"         % "9.22.3", // fixes logging
+      "org.xerial"                   % "sqlite-jdbc"         % "3.43.2.0",
+      "org.tpolecat"                %% "doobie-core"         % "1.0.0-RC4",
+      "io.github.arainko"           %% "ducktape"            % "0.1.11",
+      "com.monovore"                %% "decline-effect"      % "2.4.1",
+      "io.github.iltotore"          %% "iron"                % "2.3.0",
+      "org.tpolecat"                %% "doobie-munit"        % "1.0.0-RC4" % Test,
       "org.scalameta"               %% "munit"               % "1.0.0-M10" % Test,
-      "com.softwaremill.diffx"      %% "diffx-munit"         % "0.9.0"     % Test
+      "org.scalameta"               %% "munit-scalacheck"    % "1.0.0-M10" % Test,
+      "com.softwaremill.diffx"      %% "diffx-munit"         % "0.9.0"     % Test,
+      "io.github.iltotore"          %% "iron-scalacheck"     % "2.3.0"     % Test,
+      "com.rallyhealth"             %% "scalacheck-ops_1"    % "2.12.0"    % Test
     ),
 
     // jib docker image builder
     jibRegistry := "registry.fly.io",
     jibCustomRepositoryPath := Some("rallyeye-data"),
-    jibTags += "latest"
+    jibTags += "latest",
+
+    // for correct IOApp resource cleanup
+    Compile / run / fork := true,
+
+    // for diffx assertions in tests
+    Test / scalacOptions ++= Seq("-Xmax-inlines", "64")
   )
   .dependsOn(shared.jvm)
   .enablePlugins(AutomateHeaderPlugin)

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ dev-scala-js:
   sbt --client ~frontend/fastLinkJS
 
 dev-scala:
-  sbt --client ~backend/reStart
+  sbt --client ~backend/reStart http-server
 
 build-scala:
   sbt --client publicProd
@@ -27,3 +27,9 @@ build-backend:
 
 deploy-backend:
   cd modules/backend; flyctl deploy
+
+migrate:
+  sbt --client backend/run migrate-db
+
+rm-db:
+  rm modules/backend/rallyeye.db

--- a/modules/backend/src/main/resources/db/V001__create_initial_tables.sql
+++ b/modules/backend/src/main/resources/db/V001__create_initial_tables.sql
@@ -1,0 +1,36 @@
+CREATE TABLE rally (
+    kind INTEGER NOT NULL,
+    external_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    retrieved_at INTEGER NOT NULL,
+    PRIMARY KEY(kind, external_id)
+);
+
+CREATE TABLE results (
+    rally_kind INTEGER NOT NULL,
+    rally_external_id TEXT NOT NULL,
+
+    stage_number INTEGER NOT NULL,
+    stage_name TEXT NOT NULL,
+
+    driver_country TEXT NOT NULL,
+    driver_primary_name TEXT NOT NULL,
+    driver_secondary_name TEXT,
+    codriver_country TEXT,
+    codriver_primary_name TEXT,
+    codriver_secondary_name TEXT,
+
+    `group` TEXT NOT NULL,
+    car TEXT NOT NULL,
+
+    stage_time_ms INTEGER NOT NULL,
+    super_rally BOOLEAN NOT NULL,
+    finished BOOLEAN NOT NULL,
+    comment TEXT,
+    nominal BOOLEAN NOT NULL,
+
+    FOREIGN KEY(rally_kind, rally_external_id) REFERENCES rally(kind, external_id)
+    PRIMARY KEY(rally_kind, rally_external_id, stage_number, driver_primary_name)
+);
+
+CREATE INDEX results_kind_external_id ON results(rally_kind, rally_external_id);

--- a/modules/backend/src/main/scala/Main.scala
+++ b/modules/backend/src/main/scala/Main.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 github.com/2m/rallyeye/contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cats.effect.ExitCode
+import cats.effect.IO
+import com.monovore.decline.Opts
+import com.monovore.decline.effect.CommandIOApp
+
+object Main
+    extends CommandIOApp(
+      name = "rallyeye",
+      header = "RallyEye command line"
+    ) {
+
+  case class HttpServer()
+  case class MigrateDb()
+
+  val httpServer: Opts[HttpServer] =
+    Opts.subcommand("http-server", "Runs RallyEye HTTP server.") {
+      Opts.unit.map(_ => HttpServer())
+    }
+
+  val migrateDb: Opts[MigrateDb] =
+    Opts.subcommand("migrate-db", "Runs RallyEye DB migrations.") {
+      Opts.unit.map(_ => MigrateDb())
+    }
+
+  override def main: Opts[IO[ExitCode]] =
+    (httpServer orElse migrateDb).map {
+      case HttpServer() => rallyeye.httpServer
+      case MigrateDb() =>
+        rallyeye.storage.migrations.use { _ =>
+          IO(ExitCode.Success)
+        } <* rallyeye.storage.loadPressAutoResults("2023", "Press Auto 2023", "pressauto2023.csv")
+    }
+}

--- a/modules/backend/src/main/scala/PressAuto.scala
+++ b/modules/backend/src/main/scala/PressAuto.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 github.com/2m/rallyeye/contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rallyeye
+
+import io.github.iltotore.iron.*
+
+object PressAuto:
+  def parseResults(csv: String) =
+    def parseTimestamp(ts: String) = ts.replace(" (N)", "") match {
+      case s"$h:$m:$s.$ms" => BigDecimal(h.toInt * 3600 + m.toInt * 60 + s.toInt) + BigDecimal(s"0.$ms")
+      case _               => BigDecimal(0)
+    }
+
+    val (header :: data) = csv.split('\n').toList: @unchecked
+    val stages = header.split(";", -1).drop(6).init.zipWithIndex
+    data.map(_.split(";", -1).toList).flatMap {
+      case _ :: _ :: realName :: _ :: group :: car :: times =>
+        times.init.zip(stages).map { case (time, (stageName, stageNumber)) =>
+          Entry(
+            (stageNumber + 1).refine,
+            stageName,
+            "LT",
+            realName,
+            "",
+            group,
+            car,
+            None,
+            None,
+            parseTimestamp(time),
+            None,
+            None,
+            None,
+            false,
+            time != "",
+            "",
+            time.contains("(N)") || stageName.contains("LK Day")
+          )
+        }
+      case _ => ???
+    }

--- a/modules/backend/src/main/scala/RallyEye.scala
+++ b/modules/backend/src/main/scala/RallyEye.scala
@@ -17,16 +17,13 @@
 package rallyeye
 
 import scala.concurrent.duration._
-import scala.io.Source
 
 import cats.data.EitherT
 import cats.effect.IO
-import cats.effect.IOApp
 import cats.effect.LiftIO
 import com.comcast.ip4s._
 import org.http4s.CacheDirective
 import org.http4s.Method
-import org.http4s.client.Client
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.middleware.Caching
@@ -43,9 +40,6 @@ object Logic:
   val RallyNotStored = Error("Rally not stored")
 
   object Rsf:
-    private def rallyLink(rallyId: Int) =
-      s"https://www.rallysimfans.hu/rbr/rally_online.php?centerbox=rally_list_details.php&rally_id=$rallyId"
-
     private def fetchAndStore(rallyId: Int) =
       EmberClientBuilder
         .default[IO]

--- a/modules/backend/src/main/scala/Results.scala
+++ b/modules/backend/src/main/scala/Results.scala
@@ -19,7 +19,6 @@ package rallyeye
 import java.time.Instant
 
 import scala.collection.MapView
-import scala.util.Try
 import scala.util.chaining._
 
 import io.github.iltotore.iron.*

--- a/modules/backend/src/main/scala/Rsf.scala
+++ b/modules/backend/src/main/scala/Rsf.scala
@@ -24,8 +24,6 @@ import cats.effect.IO
 import io.github.iltotore.iron.*
 import org.http4s.client.Client
 import org.http4s.implicits._
-import rallyeye.storage.Rally
-import rallyeye.storage.RallyKind
 import sttp.tapir._
 import sttp.tapir.client.http4s.Http4sClientInterpreter
 

--- a/modules/backend/src/main/scala/storage/Db.scala
+++ b/modules/backend/src/main/scala/storage/Db.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 github.com/2m/rallyeye/contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rallyeye
+package storage
+
+import cats._
+import cats.effect._
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import org.flywaydb.core.internal.database.base.Database
+
+object Db:
+  case class Config(
+      url: String,
+      migrationsTable: String,
+      migrationsLocations: List[String]
+  )
+
+  val file = "rallyeye.db"
+
+  val config = Config(
+    url = s"jdbc:sqlite:$file",
+    migrationsTable = "flyway",
+    migrationsLocations = List("db")
+  )
+
+  val xa = {
+    val transactor = Transactor.fromDriverManager[IO](
+      driver = "org.sqlite.JDBC",
+      url = config.url,
+      logHandler = None
+    )
+    Transactor.before.modify(transactor, sql"PRAGMA foreign_keys = 1".update.run *> _)
+  }
+
+  def insertRally(rally: Rally) =
+    sql"insert or replace into rally (kind, external_id, name, retrieved_at) values ($rally)".update.run.attemptSql
+      .transact(xa)
+
+  def selectRally(kind: RallyKind, externalId: String) =
+    sql"select kind, external_id, name, retrieved_at from rally where kind = $kind and external_id = $externalId"
+      .query[Rally]
+      .option
+      .attemptSql
+      .transact(xa)
+
+  def insertManyResults(results: List[Result]) =
+    val sql = """|insert or replace into results (
+                 |  rally_kind,
+                 |  rally_external_id,
+                 |  stage_number,
+                 |  stage_name,
+                 |  driver_country,
+                 |  driver_primary_name,
+                 |  driver_secondary_name,
+                 |  codriver_country,
+                 |  codriver_primary_name,
+                 |  codriver_secondary_name,
+                 |  `group`,
+                 |  car,
+                 |  stage_time_ms,
+                 |  super_rally,
+                 |  finished,
+                 |  comment,
+                 |  nominal
+                 |) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""".stripMargin
+    Update[Result](sql)
+      .updateMany(results)
+      .attemptSql
+      .transact(xa)
+
+  def selectResults(kind: RallyKind, externalId: String) =
+    sql"""|select
+          |  rally_kind,
+          |  rally_external_id,
+          |  stage_number,
+          |  stage_name,
+          |  driver_country,
+          |  driver_primary_name,
+          |  driver_secondary_name,
+          |  codriver_country,
+          |  codriver_primary_name,
+          |  codriver_secondary_name,
+          |  `group`,
+          |  car,
+          |  stage_time_ms,
+          |  super_rally,
+          |  finished,
+          |  comment,
+          |  nominal
+          |from results where rally_kind = $kind and rally_external_id = $externalId""".stripMargin
+      .query[Result]
+      .to[List]
+      .attemptSql
+      .transact(xa)

--- a/modules/backend/src/main/scala/storage/Db.scala
+++ b/modules/backend/src/main/scala/storage/Db.scala
@@ -22,7 +22,6 @@ import cats.effect._
 import cats.implicits._
 import doobie._
 import doobie.implicits._
-import org.flywaydb.core.internal.database.base.Database
 
 object Db:
   case class Config(

--- a/modules/backend/src/main/scala/storage/Migrations.scala
+++ b/modules/backend/src/main/scala/storage/Migrations.scala
@@ -19,7 +19,6 @@ package storage
 
 import scala.io.Source
 
-import cats.effect.ExitCode
 import cats.effect.IO
 import fly4s.core.Fly4s
 import fly4s.core.data.Fly4sConfig

--- a/modules/backend/src/main/scala/storage/Migrations.scala
+++ b/modules/backend/src/main/scala/storage/Migrations.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 github.com/2m/rallyeye/contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rallyeye
+package storage
+
+import scala.io.Source
+
+import cats.effect.ExitCode
+import cats.effect.IO
+import fly4s.core.Fly4s
+import fly4s.core.data.Fly4sConfig
+import fly4s.core.data.Locations
+import fly4s.core.data.ValidatePattern
+import fly4s.implicits._
+
+val migrations = Fly4s
+  .make[IO](
+    url = Db.config.url,
+    config = Fly4sConfig(
+      table = Db.config.migrationsTable,
+      locations = Locations(Db.config.migrationsLocations),
+      ignoreMigrationPatterns = List(
+        ValidatePattern.ignorePendingMigrations
+      )
+    )
+  )
+  .evalMap(_.validateAndMigrate.result)
+
+def loadPressAutoResults(rallyId: String, name: String, filename: String) =
+  for {
+    csv <- IO.pure(Source.fromResource(filename)(scala.io.Codec.UTF8).mkString)
+    results <- IO.pure(PressAuto.parseResults(csv))
+    _ <- Repo.PressAuto.saveRallyName(rallyId, name)
+    _ <- Repo.PressAuto.saveRallyResults(rallyId, results)
+  } yield ()

--- a/modules/backend/src/main/scala/storage/Model.scala
+++ b/modules/backend/src/main/scala/storage/Model.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 github.com/2m/rallyeye/contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rallyeye
+package storage
+
+import java.time.Instant
+
+import cats.Show
+import doobie.util.{Get, Put}
+import doobie.util.Read
+import doobie.util.Write
+import io.github.iltotore.iron._
+import io.github.iltotore.iron.constraint.numeric._
+
+enum RallyKind:
+  case Rsf, PressAuto, EWrc
+
+given Write[RallyKind] = Write[Int].contramap(_.ordinal)
+given Read[RallyKind] = Read[Int].map(RallyKind.fromOrdinal)
+
+given Write[Instant] = Write[Long].contramap(_.getEpochSecond)
+given Read[Instant] = Read[Long].map(Instant.ofEpochSecond)
+
+case class Rally(kind: RallyKind, externalId: String, name: String, retrievedAt: Instant)
+
+case class Result(
+    rallyKind: RallyKind,
+    externalId: String,
+    stageNumber: Int :| Greater[0],
+    stageName: String,
+    driverCountry: String,
+    driverPrimaryName: String,
+    driverSecondaryName: Option[String],
+    codriverCountry: Option[String],
+    codriverPrimaryName: Option[String],
+    codriverSecondaryName: Option[String],
+    group: String,
+    car: String,
+    stageTimeMs: Int :| GreaterEqual[0],
+    superRally: Boolean,
+    finished: Boolean,
+    comment: Option[String],
+    nominal: Boolean
+)
+
+// doobie suport for iron constraned types
+// remove after https://github.com/Iltotore/iron/pull/184 is released
+inline given [A, C](using inline get: Get[A])(using Constraint[A, C], Show[A]): Get[A :| C] =
+  get.temap[A :| C](_.refineEither)
+
+inline given [T](using m: RefinedTypeOps.Mirror[T], ev: Get[m.IronType]): Get[T] =
+  ev.asInstanceOf[Get[T]]
+
+inline given [A, C](using inline put: Put[A])(using Constraint[A, C], Show[A]): Put[A :| C] =
+  put.tcontramap(identity)
+
+inline given [T](using m: RefinedTypeOps.Mirror[T], ev: Put[m.IronType]): Put[T] =
+  ev.asInstanceOf[Put[T]]

--- a/modules/backend/src/main/scala/storage/Repo.scala
+++ b/modules/backend/src/main/scala/storage/Repo.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 github.com/2m/rallyeye/contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rallyeye
+package storage
+
+import java.time.Instant
+
+import scala.util.chaining._
+
+import cats.data.EitherT
+import cats.effect.IO
+import cats.implicits._
+import io.github.arainko.ducktape._
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.numeric._
+
+object Repo:
+  def saveRallyName(rallyKind: RallyKind)(rallyId: String, name: String) =
+    Db.insertRally(Rally(rallyKind, rallyId.toString, name, Instant.now))
+
+  def getRally(rallyKind: RallyKind)(rallyId: Int) =
+    Db.selectRally(rallyKind, rallyId.toString)
+
+  def saveRsfRallyResults(rallyKind: RallyKind)(rallyId: String, results: List[Entry]) =
+    results
+      .map(
+        _.into[Result]
+          .transform(
+            Field.const(_.rallyKind, rallyKind),
+            Field.const(_.externalId, rallyId.toString),
+            Field.renamed(_.driverCountry, _.country),
+            Field.renamed(_.driverPrimaryName, _.userName),
+            Field.const(_.driverSecondaryName, None),
+            Field.const(_.codriverCountry, None),
+            Field.const(_.codriverPrimaryName, None),
+            Field.const(_.codriverSecondaryName, None),
+            Field.computed(_.stageTimeMs, r => (r.stageTime * 1000).toInt.refine[GreaterEqual[0]])
+          )
+      )
+      .pipe(Db.insertManyResults)
+
+  def getRsfRallyResults(rallyKind: RallyKind)(rallyId: Int) =
+    (for {
+      results <- EitherT(Db.selectResults(rallyKind, rallyId.toString))
+    } yield results.map(
+      _.into[Entry].transform(
+        Field.renamed(_.country, _.driverCountry),
+        Field.renamed(_.userName, _.driverPrimaryName),
+        Field.const(_.realName, ""), // FIXME: realName should be Option
+        Field.const(_.split1Time, None),
+        Field.const(_.split2Time, None),
+        Field.computed(_.stageTime, r => BigDecimal(r.stageTimeMs) / 1000),
+        Field.const(_.finishRealtime, None),
+        Field.const(_.penalty, None),
+        Field.const(_.servicePenalty, None),
+        Field.computed(_.comment, r => r.comment.getOrElse("")) // FIXME: comment should be Option
+      )
+    )).value
+
+  object Rsf:
+    def saveRallyName(rallyId: Int, name: String) = Repo.saveRallyName(RallyKind.Rsf)(rallyId.toString, name)
+    val getRally = Repo.getRally(RallyKind.Rsf)
+    def saveRallyResults(rallyId: Int, results: List[Entry]) =
+      Repo.saveRsfRallyResults(RallyKind.Rsf)(rallyId.toString, results)
+    val getRallyResults = Repo.getRsfRallyResults(RallyKind.Rsf)
+
+  object PressAuto:
+    val saveRallyName = Repo.saveRallyName(RallyKind.PressAuto)
+    val getRally = Repo.getRally(RallyKind.PressAuto)
+    val saveRallyResults = Repo.saveRsfRallyResults(RallyKind.PressAuto)
+    val getRallyResults = Repo.getRsfRallyResults(RallyKind.PressAuto)

--- a/modules/backend/src/main/scala/storage/Repo.scala
+++ b/modules/backend/src/main/scala/storage/Repo.scala
@@ -23,7 +23,6 @@ import scala.util.chaining._
 
 import cats.data.EitherT
 import cats.effect.IO
-import cats.implicits._
 import io.github.arainko.ducktape._
 import io.github.iltotore.iron.*
 import io.github.iltotore.iron.constraint.numeric._

--- a/modules/backend/src/test/scala/Parser.scala
+++ b/modules/backend/src/test/scala/Parser.scala
@@ -16,6 +16,10 @@
 
 package rallyeye
 
+import java.time.Instant
+
+import io.github.iltotore.iron._
+
 class ParserSuite extends munit.FunSuite:
 
   val csv =
@@ -27,7 +31,7 @@ class ParserSuite extends munit.FunSuite:
        |""".stripMargin
 
   test("parses a CSV file"):
-    val obtained = parse(csv)
+    val obtained = Rsf.parseResults(csv)
     val expected = List(
       Entry(
         1,
@@ -37,7 +41,12 @@ class ParserSuite extends munit.FunSuite:
         "David Canaleta",
         "Group A8",
         "Subaru Impreza GC8 555 GrpA",
+        Some(BigDecimal("73.3128")),
+        Some(BigDecimal("156.619")),
         250.461,
+        Some(Instant.parse("2022-10-24T16:37:02+02:00")),
+        None,
+        None,
         false,
         true,
         "good stage"
@@ -50,7 +59,12 @@ class ParserSuite extends munit.FunSuite:
         "Markas",
         "Group A8",
         "Subaru Impreza GC8 555 GrpA",
+        Some(BigDecimal("77.5726")),
+        Some(BigDecimal("161.94")),
         252.286,
+        Some(Instant.parse("2022-10-24T18:12:24+02:00")),
+        None,
+        None,
         false,
         true,
         ""
@@ -63,7 +77,12 @@ class ParserSuite extends munit.FunSuite:
         "Sami Klemetti",
         "Group A8",
         "Subaru Impreza GC8 555 GrpA",
+        Some(BigDecimal("77.767")),
+        Some(BigDecimal("160.588")),
         252.422,
+        Some(Instant.parse("2022-10-23T18:55:54+02:00")),
+        None,
+        None,
         false,
         true,
         ""
@@ -76,7 +95,12 @@ class ParserSuite extends munit.FunSuite:
         "Denas Kraulys",
         "Group A8",
         "Audi 200 quattro GrpA",
+        Some(BigDecimal("76.9378")),
+        Some(BigDecimal("161.409")),
         254.086,
+        Some(Instant.parse("2022-10-29T22:51:48+02:00")),
+        None,
+        None,
         false,
         true,
         ""

--- a/modules/backend/src/test/scala/PressAutoParser.scala
+++ b/modules/backend/src/test/scala/PressAutoParser.scala
@@ -21,6 +21,7 @@ import scala.io.Source
 
 import com.softwaremill.diffx.Diff
 import com.softwaremill.diffx.munit.DiffxAssertions
+import io.github.iltotore.iron._
 
 class PressAutoParserSuite extends munit.FunSuite with DiffxAssertions:
   given Diff[Entry] = Diff.derived[Entry]
@@ -31,7 +32,7 @@ class PressAutoParserSuite extends munit.FunSuite with DiffxAssertions:
        |""".stripMargin
 
   test("parses single driver result"):
-    val obtained = parsePressAuto(csv)
+    val obtained = PressAuto.parseResults(csv)
     val expected = List(
       Entry(
         stageNumber = 1,
@@ -354,5 +355,5 @@ class PressAutoParserSuite extends munit.FunSuite with DiffxAssertions:
 
   test("parses all results"):
     val csv = Source.fromResource("pressauto2023.csv")(Codec.UTF8).mkString
-    val obtained = parsePressAuto(csv)
+    val obtained = PressAuto.parseResults(csv)
     assertEqual(obtained.size, 1632)

--- a/modules/backend/src/test/scala/PressAutoParser.scala
+++ b/modules/backend/src/test/scala/PressAutoParser.scala
@@ -23,7 +23,7 @@ import com.softwaremill.diffx.Diff
 import com.softwaremill.diffx.munit.DiffxAssertions
 import io.github.iltotore.iron._
 
-class PressAutoParserSuite extends munit.FunSuite with DiffxAssertions:
+class PressAutoParserSuite extends munit.FunSuite with DiffxAssertions with IronSupport:
   given Diff[Entry] = Diff.derived[Entry]
 
   val csv =

--- a/modules/backend/src/test/scala/Results.scala
+++ b/modules/backend/src/test/scala/Results.scala
@@ -16,9 +16,14 @@
 
 package rallyeye
 
-import com.softwaremill.diffx.Diff
+import java.time.Instant
+
+import com.softwaremill.diffx.generic.auto.given
 import com.softwaremill.diffx.munit.DiffxAssertions
+import io.github.iltotore.iron._
 import rallyeye.shared._
+import rallyeye.storage.Rally
+import rallyeye.storage.RallyKind
 
 class ResultsSuite extends munit.FunSuite with DiffxAssertions:
   given Diff[CarResults] = Diff.derived[CarResults]
@@ -29,10 +34,78 @@ class ResultsSuite extends munit.FunSuite with DiffxAssertions:
   given Diff[Driver] = Diff.derived[Driver]
 
   val entries = List(
-    Entry(1, "SS1", "LT", "driver1", "name1", "group1", "car1", 10.1, false, true, "good stage"),
-    Entry(1, "SS1", "LT", "driver2", "name2", "group1", "car2", 14.9, false, true, "good stage"),
-    Entry(2, "SS2", "LT", "driver1", "name1", "group1", "car1", 20.5, false, true, "good stage"),
-    Entry(2, "SS2", "LT", "driver2", "name2", "group1", "car2", 24.5, false, true, "good stage")
+    Entry(
+      1,
+      "SS1",
+      "LT",
+      "driver1",
+      "name1",
+      "group1",
+      "car1",
+      None,
+      None,
+      10.1,
+      None,
+      None,
+      None,
+      false,
+      true,
+      "good stage"
+    ),
+    Entry(
+      1,
+      "SS1",
+      "LT",
+      "driver2",
+      "name2",
+      "group1",
+      "car2",
+      None,
+      None,
+      14.9,
+      None,
+      None,
+      None,
+      false,
+      true,
+      "good stage"
+    ),
+    Entry(
+      2,
+      "SS2",
+      "LT",
+      "driver1",
+      "name1",
+      "group1",
+      "car1",
+      None,
+      None,
+      20.5,
+      None,
+      None,
+      None,
+      false,
+      true,
+      "good stage"
+    ),
+    Entry(
+      2,
+      "SS2",
+      "LT",
+      "driver2",
+      "name2",
+      "group1",
+      "car2",
+      None,
+      None,
+      24.5,
+      None,
+      None,
+      None,
+      false,
+      true,
+      "good stage"
+    )
   )
 
   test("gives results"):
@@ -51,12 +124,13 @@ class ResultsSuite extends munit.FunSuite with DiffxAssertions:
     assertEquals(obtained, expected)
 
   test("gives rally results"):
-    val obtained = rally(1, "rally", "link", entries)
+    val rally = Rally(RallyKind.Rsf, "1", "rally", Instant.now)
+    val obtained = rallyData(rally, entries)
     val expected = RallyData(
-      1,
-      "rally",
-      "link",
-      obtained.retrievedAt,
+      rally.externalId.toInt,
+      rally.name,
+      rally.kind.link(rally),
+      rally.retrievedAt,
       List(
         Stage(1, "SS1"),
         Stage(2, "SS2")

--- a/modules/backend/src/test/scala/Results.scala
+++ b/modules/backend/src/test/scala/Results.scala
@@ -18,7 +18,7 @@ package rallyeye
 
 import java.time.Instant
 
-import com.softwaremill.diffx.generic.auto.given
+import com.softwaremill.diffx.Diff
 import com.softwaremill.diffx.munit.DiffxAssertions
 import io.github.iltotore.iron._
 import rallyeye.shared._

--- a/modules/backend/src/test/scala/iron.scala
+++ b/modules/backend/src/test/scala/iron.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 github.com/2m/rallyeye/contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rallyeye
+
+import com.softwaremill.diffx.Diff
+import io.github.iltotore.iron._
+
+trait IronSupport {
+  implicit def ironDiff[T: Diff, P]: Diff[T IronType P] = Diff[T].contramap[T IronType P](identity)
+}

--- a/modules/backend/src/test/scala/storage/DbSuite.scala
+++ b/modules/backend/src/test/scala/storage/DbSuite.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2022 github.com/2m/rallyeye/contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rallyeye
+package storage
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.sql.SQLException
+import java.time.Instant
+
+import scala.collection.GenSet
+import scala.collection.immutable.ArraySeq
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.implicits._
+import com.softwaremill.diffx.Diff
+import com.softwaremill.diffx.munit.DiffxAssertions
+import doobie.implicits._
+import io.github.iltotore.iron._
+import io.github.iltotore.iron.constraint.numeric._
+import io.github.iltotore.iron.scalacheck.numeric.given
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+import org.scalacheck.Test
+import org.scalacheck.ops._
+
+trait IronSupport {
+  implicit def ironDiff[T: Diff, P]: Diff[T IronType P] = Diff[T].contramap[T IronType P](identity)
+}
+
+class DbSuite extends munit.ScalaCheckSuite with DiffxAssertions with IronSupport:
+  import cats.effect.unsafe.implicits.global
+
+  given Diff[Instant] = Diff[Long].contramap(_.getEpochSecond)
+  given Diff[RallyKind] = Diff.derived[RallyKind]
+  given Diff[Rally] = Diff.derived[Rally]
+  given Diff[Result] = Diff.derived[Result]
+  given Diff[SQLException] = Diff[String].contramap(_.getMessage)
+
+  case class RallyWithResults(rally: Rally, results: List[Result])
+
+  given Arbitrary[RallyKind] = Arbitrary:
+    Gen.oneOf(ArraySeq.unsafeWrapArray(RallyKind.values))
+  given Arbitrary[Rally] = Arbitrary:
+    Gen.resultOf(Rally.apply _)
+  given Arbitrary[Result] = Arbitrary:
+    Gen.resultOf(Result.apply _)
+  given Arbitrary[RallyWithResults] = Arbitrary:
+    for
+      rally <- arbitrary[Rally]
+      stageCount <- Gen.oneOf(1 to 10)
+      stageNumbers <- Gen.setOfN(stageCount, arbitrary[Int :| Greater[0]])
+      driverCount <- Gen.oneOf(1 to 10)
+      driverNames <- Gen.setOfN(driverCount, arbitrary[String])
+    yield
+      val results =
+        for
+          stageNumber <- stageNumbers
+          driverName <- driverNames
+        yield arbitrary[Result].sample.get.copy(
+          rallyKind = rally.kind,
+          externalId = rally.externalId,
+          stageNumber = stageNumber,
+          driverPrimaryName = driverName
+        )
+      RallyWithResults(rally, results.toList)
+
+  val db = FunFixture[Unit](
+    setup = { test =>
+      Files.deleteIfExists(Paths.get(Db.file))
+      migrations.use(_ => IO.unit).unsafeRunSync()
+    },
+    teardown = { _ => }
+  )
+
+  db.test("should insert and select rally") { _ =>
+    Prop.forAll { (rally: Rally) =>
+      val inserted = Db.insertRally(rally).unsafeRunSync()
+      assertEqual(inserted, Right(1))
+
+      val selected = Db.selectRally(rally.kind, rally.externalId).unsafeRunSync()
+      assertEqual(selected, Right(Some(rally)))
+    }
+  }
+
+  db.test("should insert and select results") { _ =>
+    Prop.forAll { (rallyWithResults: RallyWithResults) =>
+      sql"delete from results".update.run.attemptSql.transact(Db.xa).unsafeRunSync()
+
+      val RallyWithResults(rally, results) = rallyWithResults
+      Db.insertRally(rally).unsafeRunSync()
+
+      val inserted = Db
+        .insertManyResults(results)
+        .unsafeRunSync()
+      assertEqual(inserted, Right(results.size))
+
+      val selected = Db.selectResults(rally.kind, rally.externalId).unsafeRunSync()
+      assertEquals(selected, Right(results))
+    }
+  }
+
+  db.test("should insert or update rally") { _ =>
+    val rally = arbitrary[Rally].sample.get
+    val inserted = Db.insertRally(rally).unsafeRunSync()
+    assertEqual(inserted, Right(1))
+
+    val rally2 = rally.copy(name = rally.name + " changed")
+    val inserted2 = Db.insertRally(rally2).unsafeRunSync()
+    assertEqual(inserted2, Right(1))
+
+    val selected = Db.selectRally(rally.kind, rally.externalId).unsafeRunSync()
+    assertEqual(selected, Right(Some(rally2)))
+  }
+
+  db.test("should insert or update results") { _ =>
+    val RallyWithResults(rally, results) = arbitrary[RallyWithResults].sample.get
+    val result = results.head
+
+    Db.insertRally(rally).unsafeRunSync()
+
+    val inserted = Db.insertManyResults(List(result)).unsafeRunSync()
+    assertEqual(inserted, Right(1))
+
+    val result2 = result.copy(stageName = result.stageName + " changed")
+    val inserted2 = Db.insertManyResults(List(result2)).unsafeRunSync()
+    assertEqual(inserted2, Right(1))
+
+    val selected = Db.selectResults(rally.kind, rally.externalId).unsafeRunSync()
+    assertEqual(selected, Right(List(result2)))
+  }

--- a/modules/backend/src/test/scala/storage/DbSuite.scala
+++ b/modules/backend/src/test/scala/storage/DbSuite.scala
@@ -22,12 +22,9 @@ import java.nio.file.Paths
 import java.sql.SQLException
 import java.time.Instant
 
-import scala.collection.GenSet
 import scala.collection.immutable.ArraySeq
 
-import cats.data.NonEmptyList
 import cats.effect.IO
-import cats.implicits._
 import com.softwaremill.diffx.Diff
 import com.softwaremill.diffx.munit.DiffxAssertions
 import doobie.implicits._
@@ -38,12 +35,7 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Prop
-import org.scalacheck.Test
 import org.scalacheck.ops._
-
-trait IronSupport {
-  implicit def ironDiff[T: Diff, P]: Diff[T IronType P] = Diff[T].contramap[T IronType P](identity)
-}
 
 class DbSuite extends munit.ScalaCheckSuite with DiffxAssertions with IronSupport:
   import cats.effect.unsafe.implicits.global

--- a/modules/frontend/src/main/scala/Results.scala
+++ b/modules/frontend/src/main/scala/Results.scala
@@ -16,8 +16,6 @@
 
 package rallyeye
 
-import scala.concurrent.Future
-import scala.concurrent.duration._
 import scala.util.chaining._
 
 import org.scalajs.dom
@@ -25,7 +23,6 @@ import rallyeye.shared._
 import sttp.client3._
 import sttp.tapir.DecodeResult
 import sttp.tapir.client.sttp.SttpClientInterpreter
-import sttp.tapir.header
 
 def fetch(rallyId: Int, endpoint: Endpoint) =
   val baseUri =

--- a/modules/frontend/src/main/scala/Results.scala
+++ b/modules/frontend/src/main/scala/Results.scala
@@ -27,25 +27,16 @@ import sttp.tapir.DecodeResult
 import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.tapir.header
 
-def fetch(rallyId: Int, endpoint: Endpoint, useCache: Boolean = true) =
+def fetch(rallyId: Int, endpoint: Endpoint) =
   val baseUri =
     if BuildInfo.isSnapshot then uri"http://${dom.window.location.hostname}:8080"
     else uri"https://rallyeye-data.fly.dev"
 
-  val client =
-    SttpClientInterpreter().toClient(
-      endpoint.in(header("Cache-Control", if useCache then s"max-age=${3.hours.toSeconds}" else "no-cache")),
-      Some(baseUri),
-      FetchBackend()
-    )
+  val client = SttpClientInterpreter().toClient(endpoint, Some(baseUri), FetchBackend())
   val response = client(rallyId)
 
   import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
-  response.flatMap {
-    case DecodeResult.Value(r) =>
-      r match {
-        case Right(rallyData) => Future.successful(rallyData)
-        case Left(_)          => Future.failed(new Exception("Error decoding response"))
-      }
-    case error => Future.failed(new Exception(error.toString))
+  response.map {
+    case DecodeResult.Value(r) => r
+    case error                 => Left(GenericError(error.toString))
   }

--- a/modules/shared/src/main/scala/borer.scala
+++ b/modules/shared/src/main/scala/borer.scala
@@ -47,5 +47,5 @@ object TapirJsonBorer:
     }(t => io.bullet.borer.Json.encode(t).toUtf8String)
 
 object Codecs:
-  given Encoder[Instant] = Encoder[Long].contramap(_.toEpochMilli)
-  given Decoder[Instant] = Decoder[Long].map(Instant.ofEpochMilli(_))
+  given Encoder[Instant] = Encoder[Long].contramap(_.getEpochSecond)
+  given Decoder[Instant] = Decoder[Long].map(Instant.ofEpochSecond)


### PR DESCRIPTION
Will use [LiteFS](https://fly.io/docs/litefs/) when deployed. Therefore server API was refactored into two requests:
* GET - for only results retrieval
* POST - for retrieving results and storing to DB

This will make it possible to run multiple instances with separate databases where replication will be taken care by LiteFS. POST requests will be automatically routed to primary node and GET requests to all nodes.