### PR TITLE
Delete stored results on refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-rallyeye.db
-rallyeye.db.bak
+rallyeye.db*
 *.new.json
 .env

--- a/justfile
+++ b/justfile
@@ -60,4 +60,4 @@ ssh:
   fly ssh console --select
 
 litefs-export:
-  cd modules/backend; flyctl litefs-cloud export --cluster rallyeye --database rallyeye.db --output ./rallyeye.db
+  cd modules/backend; flyctl litefs-cloud export --cluster rallyeye --database rallyeye.db --output ./rallyeye.db.$(date "+%Y-%m-%d")

--- a/modules/backend/src/main/scala/RallyEye.scala
+++ b/modules/backend/src/main/scala/RallyEye.scala
@@ -58,6 +58,7 @@ object Logic:
           (for
             info <- rallyeye.Rsf.rallyInfo(client, rallyId)
             results <- rallyeye.Rsf.rallyResults(client, rallyId)
+            _ <- EitherT(Repo.Rsf.deleteResultsAndRally(rallyId))
             _ <- EitherT(Repo.Rsf.saveRallyInfo(rallyId, info))
             _ <- EitherT(Repo.Rsf.saveRallyResults(rallyId, results))
           yield ()).value
@@ -101,6 +102,7 @@ object Logic:
           (for
             info <- rallyeye.Ewrc.rallyInfo(client, rallyId)
             results <- rallyeye.Ewrc.rallyResults(client, rallyId)
+            _ <- EitherT(Repo.Ewrc.deleteResultsAndRally(rallyId))
             _ <- EitherT(Repo.Ewrc.saveRallyInfo(rallyId, info))
             _ <- EitherT(Repo.Ewrc.saveRallyResults(rallyId, results))
           yield ()).value


### PR DESCRIPTION
This fixes stale results, when updated parser returns less results than before.